### PR TITLE
header-edit

### DIFF
--- a/app/views/messages/_chat-main.html.haml
+++ b/app/views/messages/_chat-main.html.haml
@@ -1,12 +1,12 @@
 .main-header
   .main-header__left-box 
     %h2.main-header__left-box__current-group
-      テストグループ
+      = @group.name
     %ul.main-header__left-box__member-list
       Member:
       %li.main-header__left-box__member-list__member
-        tomo
+        = current_user.name
 
-    =link_to "/" do
-      .main-header__edit-btn
-        Edit
+  =link_to "/" do
+    .main-header__edit-btn
+      Edit


### PR DESCRIPTION
# What
メッセージヘッダー部分のグループ名とユーザー名を自動表示。

# Why
ユーザー毎に名前を表示する必要があるため。